### PR TITLE
Add dual licensing and footer snippets

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 HybridSec
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE-CC-BY-4.0.txt
+++ b/LICENSE-CC-BY-4.0.txt
@@ -1,0 +1,7 @@
+Creative Commons Attribution 4.0 International
+
+The documentation and other content in this repository, including the Enterprise Cyber Defense Doctrine manual, field cards, and images, are licensed under the Creative Commons Attribution 4.0 International License.
+
+You are free to share and adapt the content for any purpose, even commercially, provided that you give appropriate credit, provide a link to the license, and indicate if changes were made.
+
+To view a copy of this license, visit https://creativecommons.org/licenses/by/4.0/.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,9 @@
+Enterprise Cyber Defense Doctrine
+Copyright (c) 2024 HybridSec
+
+This project uses a dual-license model:
+
+- Code is released under the MIT License. See LICENSE.
+- Documentation and other content, including the Enterprise Cyber Defense Doctrine manual, field cards, and images, are released under the Creative Commons Attribution 4.0 International License. See LICENSE-CC-BY-4.0.txt.
+
+When redistributing or adapting this project, please attribute "HybridSec – Enterprise Cyber Defense Doctrine" and include links to the relevant license files.

--- a/README-License-Section.md
+++ b/README-License-Section.md
@@ -1,0 +1,6 @@
+## License
+
+- **Code** in this repository is licensed under the [MIT License](./LICENSE).
+- **Content** (the doctrine manual, field cards, images, and other documentation) is licensed under the [Creative Commons Attribution 4.0 International License](./LICENSE-CC-BY-4.0.txt).
+
+See the [NOTICE](./NOTICE) file for attribution guidance.

--- a/README.md
+++ b/README.md
@@ -66,8 +66,11 @@ We welcome contributions from the cybersecurity community. Collaboration is the 
 ---
 
 ## License
-This project is released under the **MIT License**.  
-You are free to use, modify, and distribute the manual, with attribution.
+
+- **Code** in this repository is licensed under the [MIT License](./LICENSE).
+- **Content** (the doctrine manual, field cards, images, and other documentation) is licensed under the [Creative Commons Attribution 4.0 International License](./LICENSE-CC-BY-4.0.txt).
+
+See the [NOTICE](./NOTICE) file for attribution guidance.
 
 ---
 

--- a/website-footer-react.jsx
+++ b/website-footer-react.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function WebsiteFooter() {
+  return (
+    <footer>
+      <p>
+        Code licensed under <a href="/LICENSE">MIT</a>. Content licensed under <a href="/LICENSE-CC-BY-4.0.txt">CC BY 4.0</a>.
+      </p>
+    </footer>
+  );
+}

--- a/website-footer.html
+++ b/website-footer.html
@@ -1,0 +1,5 @@
+<footer>
+  <p>
+    Code licensed under <a href="/LICENSE">MIT</a>. Content licensed under <a href="/LICENSE-CC-BY-4.0.txt">CC BY 4.0</a>.
+  </p>
+</footer>


### PR DESCRIPTION
## Summary
- add MIT license, CC BY 4.0 content license, and notice files
- update README with licensing details and provide reusable license section
- include HTML and React website footer snippets referencing license files

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b63679e6a083239472bcf9fce934e6